### PR TITLE
Fix prior range for pocoMC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Date: 2024-XX-XX
 - Delete unused dependencies and add `requirements.txt`
 - Running the scripts parsing arguments from the terminal is no longer supported
 - Move all examples to the `examples` directory
+- Fix range of pocoMC uniform prior distributions. This does not cause problems with previous results, since the `log_likelihood` evaluates to `-np.inf` for values outside the prior range.
 
 ## v1.1.0
 Date: 2024-07-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Date: 2024-XX-XX
 - Delete unused dependencies and add `requirements.txt`
 - Running the scripts parsing arguments from the terminal is no longer supported
 - Move all examples to the `examples` directory
-- Fix range of pocoMC uniform prior distributions. This does not cause problems with previous results, since the `log_likelihood` evaluates to `-np.inf` for values outside the prior range.
+- Fix range of pocoMC uniform prior distributions. This does not cause problems with previous results, since the `log_likelihood` evaluates to `-np.inf` for values outside the prior range. Thanks @wenbin1501110084 for pointing this out.
 
 ## v1.1.0
 Date: 2024-07-24

--- a/src/mcmc.py
+++ b/src/mcmc.py
@@ -930,7 +930,8 @@ class Chain:
         logging.info('Generate the prior class for pocoMC ...')
         prior_distributions = []
         for i in range(self.ndim):
-            prior_distributions.append(uniform(self.min[i], self.max[i]))
+            prior_distributions.append(uniform(self.min[i], 
+                                               self.max[i] - self.min[i]))
         prior = pocomc.Prior(prior_distributions)
 
         logging.info('Starting pocoMC ...')


### PR DESCRIPTION
This fixes the prior range for the pocoMC sampler wrapper function.

The bug does not affect the previous results, since the lower value is correct and the upper value is always too large. The values out of the prior range are effectively removed in the `log_likelihood` function by setting the value to `-np.inf`.