### PR TITLE
v2.0.0 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Date: 2025-09-17
 
 - Fix the standard behavior of the pocoMC sampler to resample the samples (i.e., make them have equal weights). The resampled points can be used just like you would do with MCMC samples. In older versions the 'weights' from the chain have to be used to generate the posterior corner plots. Thanks to @hejajama for pointing this out.
 - Update to surmise 0.3.0. This update in our `predict` function is not backward compatible, since the handling of the covariance matrices has changed. `fpredcov = gp.covx().transpose((1, 0, 2))` has to be used when using older versions of surmise (<=0.2.1) or emulators trained with that version. The new version (0.3.0) returns the covariance matrices in the expected shape `(theta, ndim, ndim)`, so `fpredcov = gp.covx()` is sufficient.
+- Increase the default `n_steps` for the pocoMC sampler to `2*ndim` (twice the number of dimensions). This should improve the exploration of the posterior distribution. The default value was `ndim` in previous versions.
 
 [Link to diff from previous version](https://github.com/Hendrik1704/GPBayesTools-HIC/compare/v1.2.1...v2.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v2.0.0
+Date: 2025-09-17
+
+- Fix the standard behavior of the pocoMC sampler to resample the samples (i.e., make them have equal weights). The resampled points can be used just like you would do with MCMC samples.
+
+[Link to diff from previous version](https://github.com/Hendrik1704/GPBayesTools-HIC/compare/v1.2.1...v2.0.0)
+
 ## v1.2.1
 Date: 2025-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## v2.0.0
 Date: 2025-09-17
 
-- Fix the standard behavior of the pocoMC sampler to resample the samples (i.e., make them have equal weights). The resampled points can be used just like you would do with MCMC samples.
-- Update to surmise 0.3.0. This update in our `predict` function is not backward compatible, since the handling of the covariance matrices has changed. `fpredcov = gp.covx().transpose((1, 0, 2))` has to be used when using older versions of surmise (<=0.2.1). The new version (0.3.0) returns the covariance matrices in the correct shape, so `fpredcov = gp.covx()` is sufficient.
+- Fix the standard behavior of the pocoMC sampler to resample the samples (i.e., make them have equal weights). The resampled points can be used just like you would do with MCMC samples. In older versions the 'weights' from the chain have to be used to generate the posterior corner plots. Thanks to @hejajama for pointing this out.
+- Update to surmise 0.3.0. This update in our `predict` function is not backward compatible, since the handling of the covariance matrices has changed. `fpredcov = gp.covx().transpose((1, 0, 2))` has to be used when using older versions of surmise (<=0.2.1) or emulators trained with that version. The new version (0.3.0) returns the covariance matrices in the expected shape `(theta, ndim, ndim)`, so `fpredcov = gp.covx()` is sufficient.
 
 [Link to diff from previous version](https://github.com/Hendrik1704/GPBayesTools-HIC/compare/v1.2.1...v2.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Date: 2025-09-17
 
 - Fix the standard behavior of the pocoMC sampler to resample the samples (i.e., make them have equal weights). The resampled points can be used just like you would do with MCMC samples.
+- Update to surmise 0.3.0. This update in our `predict` function is not backward compatible, since the handling of the covariance matrices has changed. `fpredcov = gp.covx().transpose((1, 0, 2))` has to be used when using older versions of surmise (<=0.2.1). The new version (0.3.0) returns the covariance matrices in the correct shape, so `fpredcov = gp.covx()` is sufficient.
 
 [Link to diff from previous version](https://github.com/Hendrik1704/GPBayesTools-HIC/compare/v1.2.1...v2.0.0)
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,18 @@
+Credits
+=======
+
+The GPBayesTools-HIC Team
+-------------------------
+
+Author  |  GH Username
+:----:  |  :----: 
+Sayed Afrid Jahan | @Afrid165
+Hendrik Roch | @Hendrik1704
+
+
+Contributors
+------------
+Contributor  |  GH Username
+:----:  |  :----:
+Heikki Mäntysaari | @hejajama
+Wenbin Zhao | @wenbin1501110084

--- a/examples/generate_posterior_clusters.py
+++ b/examples/generate_posterior_clusters.py
@@ -9,7 +9,6 @@ def read_pkl_file_chain_pocoMC(PATH_pklfile_chain):
     Reads a pickle file containing the chain data from pocoMC.
     The expected structure of the data is:
     - 'chain'
-    - 'weights'
     - 'logl'
     - 'logp'
     - 'logz'
@@ -28,7 +27,6 @@ def sort_chain_likelihood(PATH_pklfile_chain):
     """
     run_chain = read_pkl_file_chain_pocoMC(PATH_pklfile_chain)
     array_chain = run_chain['chain']
-    array_weights = run_chain['weights']
     array_logl = run_chain['logl']
     array_logp = run_chain['logp']
     array_logz = run_chain['logz']
@@ -40,15 +38,13 @@ def sort_chain_likelihood(PATH_pklfile_chain):
     sorted_array_logl = array_logl[sorted_indices]
     # sort also the other arrays
     sorted_array_chain = array_chain[sorted_indices]
-    sorted_array_weights = array_weights[sorted_indices]
     sorted_array_logp = array_logp[sorted_indices]
 
     # write a new file with the same content and the sorted data
-    data = {'chain': sorted_array_chain, 
-            'weights': sorted_array_weights, 
-            'logl': sorted_array_logl, 
-            'logp': sorted_array_logp, 
-            'logz': array_logz, 
+    data = {'chain': sorted_array_chain,
+            'logl': sorted_array_logl,
+            'logp': sorted_array_logp,
+            'logz': array_logz,
             'logz_err': array_logz_err
             }
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-surmise==0.2.1 # new version 0.3.0 is released, but we have not tested it yet (needs modifications for the covariance matrix handling)
+surmise==0.3.0
 pocomc==1.2.6
 
 # versions that work for us, maybe also versions lower than that work, but we have not tested them

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -30,4 +30,5 @@ def parse_model_parameter_file(parfile):
             for i in range(1, 3):
                 val[i] = float(val[i])
             pardict.update({key: val})
+    f.close()
     return pardict

--- a/src/emulator_BAND.py
+++ b/src/emulator_BAND.py
@@ -368,7 +368,7 @@ class EmulatorBAND:
         else:
             fpredmean = gp.mean()
 
-        fpredcov = gp.covx().transpose((1, 0, 2))
+        fpredcov = gp.covx()
 
         if self.exp_and_cov_diagonal_:
             fcov = np.zeros((theta.shape[0], self.nobs, self.nobs))
@@ -460,7 +460,7 @@ class EmulatorBAND:
         else:
             fpredmean = gp.mean().T
 
-        fpredcov = gp.covx().transpose((1, 0, 2))
+        fpredcov = gp.covx()
 
         if self.exp_and_cov_diagonal_:
             fcov = np.zeros((X.shape[0], self.nobs, self.nobs))

--- a/src/mcmc.py
+++ b/src/mcmc.py
@@ -805,7 +805,7 @@ class Chain:
         sampler.run(n_total=n_total, n_evidence=n_evidence)
 
         logging.info('Generate the posterior samples ...')
-        samples, weights, logl, logp = sampler.posterior(resample=True)
+        samples, logl, logp = sampler.posterior(resample=True)
 
         logging.info('Generate the evidence ...')
         logz, logz_err = sampler.evidence()
@@ -813,7 +813,7 @@ class Chain:
         logging.info('Log evidence error: {}'.format(logz_err))
 
         logging.info('Writing pocoMC chains to file...')
-        chain_data = {'chain': samples, 'weights': weights, 'logl': logl,
+        chain_data = {'chain': samples, 'logl': logl,
                         'logp': logp, 'logz': logz, 'logz_err': logz_err}
         with open(self.mcmc_path, 'wb') as file:
             pickle.dump(chain_data, file)

--- a/src/mcmc.py
+++ b/src/mcmc.py
@@ -805,10 +805,10 @@ class Chain:
         sampler.run(n_total=n_total, n_evidence=n_evidence)
 
         logging.info('Generate the posterior samples ...')
-        samples, weights, logl, logp = sampler.posterior() # Weighted posterior samples
+        samples, weights, logl, logp = sampler.posterior(resample=True)
 
         logging.info('Generate the evidence ...')
-        logz, logz_err = sampler.evidence() # Bayesian model evidence estimate and uncertainty
+        logz, logz_err = sampler.evidence()
         logging.info('Log evidence: {}'.format(logz))
         logging.info('Log evidence error: {}'.format(logz_err))
 

--- a/src/mcmc.py
+++ b/src/mcmc.py
@@ -800,6 +800,7 @@ class Chain:
                                 n_effective=n_effective, n_active=n_active, 
                                 n_prior=n_prior, sample=sample, 
                                 n_max_steps=n_max_steps, 
+                                n_steps=2*self.ndim,
                                 random_state=random_state, vectorize=True, 
                                 pool=pool)
         sampler.run(n_total=n_total, n_evidence=n_evidence)


### PR DESCRIPTION
This closes #7 (surmise update) and also removes the `weight` key from the chain file. The posterior is resampled so that it is not necessary to deal with the weights.

I updated the version number to 2.0.0 since the changes are not backward compatible if old emulators are used with the new code.

I have tested the new chain file production in a small run and also trained new emulators using numpy 2.3 in addition to the new surmise. Everything works properly. 